### PR TITLE
Refactor `tryGet` to take options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `CacheClient` exposes a `tryGet` function that takes a key, a `fallback` fun
 **Options**:
 * `ttl` default(defaultTTL): Time to live for the key after which the key expires.
 * `deserialize` default(`true`): Call `deserialize` on the cached value
-* `addTimestamp` default(`true`): Add a timestamp to the cached value
+* `addTimestamp` default(`true`): Add a time-stamp to the cached value
 * `throwOnError` default(`false`): If `true` any errors while calling `fallback` will be thrown, else returned in the value
 * `forceCacheMiss` default(`false`): Function or boolean to check if we want to force `fallback` call.
 
@@ -27,6 +27,22 @@ The `CacheClient` exposes a `tryGet` function that takes a key, a `fallback` fun
 result = await cache.tryGet(query, async _ => {
     return await service.query(query);
 });
+```
+
+
+#### Key Hashing
+
+We can use strings or objects as the raw source for the cache key. If the raw key is an object will be serialized to a string.
+Then the create an `md5` hash with the key and prepped the `cacheKeyPrefix`.
+
+By default the `serialize` and `deserialize` functions are mapped to `JSON.stringify` and `JSON.parse` respectively.
+
+If our raw key is the following object:
+
+```js
+const query = { limit: 100, order: 'DESC', where: { id: 23 } };
+let key = cache.hashKey(query);
+assert(key === 'cache:1239ecd04b073b8f4615d4077be5e263');
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,13 +1,32 @@
 ## core.io Cache Redis
 
-
-
 This package provides a module for the [core.io](https://npmjs.com/package/core.io) library.
 
 ### Install
 
 ```
 $ npm i -S core.io-cache-redis
+```
+
+### Usage
+
+The `CacheClient` exposes a `tryGet` function that takes a key, a `fallback` function and an options object.
+
+* `key`: Either a string or an object that will be used to create a cache identification key. If key is not found in the cache we call `fallback` and store the functions output in cache using key as identifier. Next time we call `tryGet` we return the cached value.
+* `fallback`: Some (expensive) function that we want to cache the outputs of its execution.
+
+**Options**:
+* `ttl` default(defaultTTL): Time to live for the key after which the key expires.
+* `deserialize` default(`true`): Call `deserialize` on the cached value
+* `addTimestamp` default(`true`): Add a timestamp to the cached value
+* `throwOnError` default(`false`): If `true` any errors while calling `fallback` will be thrown, else returned in the value
+* `forceCacheMiss` default(`false`): Function or boolean to check if we want to force `fallback` call.
+
+
+```js
+result = await cache.tryGet(query, async _ => {
+    return await service.query(query);
+});
 ```
 
 ## License

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -74,22 +74,20 @@ class CacheClient extends EventEmitter {
 
         key = this.hashKey(key);
 
-        this.logger.info('try to fetch key "%s"...', key);
-
         let value;
 
         if (this.shouldQueryCache(key, options)) {
-            this.logger.info('fetching key "%s" from cache...', key);
+            this.logger.info('fetching "%s"', key);
             value = await this.get(key, false, options.deserialize);
         }
 
         if (value) {
-            this.logger.info('value was cached, return');
+            this.logger.info('returning cached value!');
             return value;
         }
 
         try {
-            this.logger.info('calling fallback for key "%s"...', key);
+            this.logger.info('cache miss "%s"', key);
 
             value = await fallback();
 
@@ -141,8 +139,9 @@ class CacheClient extends EventEmitter {
     }
 
     /**
-     * Remove key from ache
+     * Remove key from cache.
      * @param {String} key cache key
+     * @param {Object} key cache key
      * @returns {Promise}
      */
     del(key) {
@@ -151,7 +150,18 @@ class CacheClient extends EventEmitter {
     }
 
     /**
-     * Format key.
+     * Format `key`.
+     *
+     * If `key` is an object it will be
+     * `serialize`d into a string.
+     *
+     * If `key` is a string it will be hashed
+     * and appended to `cacheKeyPrefix`.
+     *
+     * Keys look like:
+     * ```js
+     * cache:1239ecd04b073b8f4615d4077be5e263
+     * ```
      * @param {String} key raw value to hash
      * @param {Object} key raw value to hash
      * @returns {String} Formatted key
@@ -167,6 +177,57 @@ class CacheClient extends EventEmitter {
     isHashKey(key) {
         if (typeof key !== 'string') key = this.serialize(key);
         return !!this.cacheKeyMatcher.exec(key);
+    }
+
+    /**
+     * Purge all keys matching the `match` pattern.
+     *
+     * @param {String} match Pattern to match
+     * @param {Integer} count Number of keys per cycle
+     * @returns {Promise}
+     */
+    purgeKeys(match = this.cacheKeyPrefix, count = 100) {
+        const stream = this.client.scanStream({
+            match,
+            count,
+        });
+
+        let total = 0,
+            step = 0;
+        let pipeline = this.client.pipeline();
+
+        return new Promise((resolve, reject) => {
+            stream.on('data', async(keys = []) => {
+                step += keys.length;
+                total += keys.length;
+
+                for (let key of keys) pipeline.del(key);
+
+                if (step > count) {
+                    await pipeline.exec();
+                    step = 0;
+                    pipeline = this.client.pipeline();
+                    this.logger.info('cache purging keys...');
+                }
+            });
+
+            stream.on('end', async _ => {
+                if (pipeline) await pipeline.exec();
+
+                this.logger.info('cache purged %s keys!', total);
+
+                resolve({
+                    match,
+                    total,
+                });
+            });
+
+            stream.on('error', error => {
+                this.logger.error('Error purging keys: %s', match);
+                this.logger.error(error);
+                reject(error);
+            });
+        });
     }
 
     shouldQueryCache(key, options) {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -62,7 +62,7 @@ class CacheClient extends EventEmitter {
      * @param {Function} fallback Called on cache miss
      * @param {Object} options
      * @param {Int} [options.ttl=defaultTTL] TTL for this key
-     * @param {Boolean} [options.serialize=true] Retrieve content as JSON
+     * @param {Boolean} [options.deserialize=true] Retrieve content as JSON
      * @param {Boolean} [options.addTimestamp=true] Include a timestamp to payload
      * @param {Boolean} [options.throwOnError=false] Throw if fallback errors
      * @param {Boolean} [options.forceCacheMiss=false] Throw if fallback errors
@@ -80,7 +80,7 @@ class CacheClient extends EventEmitter {
 
         if (this.shouldQueryCache(key, options)) {
             this.logger.info('fetching key "%s" from cache...', key);
-            value = await this.get(key, false, options.serialize);
+            value = await this.get(key, false, options.deserialize);
         }
 
         if (value) {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -54,22 +54,34 @@ class CacheClient extends EventEmitter {
     /**
      * Get object related to `key` if present, if cache miss
      * we run `fallback` and cache the value returned from that.
-     * 
-     * @param {String} key raw key 
-     * @param {Function} fallback Called on cache miss 
-     * @param {Int} ttl TTL for this key
-     * @param {Boolean} [serialize=true] Retrieve content as JSON
-     * @param {Boolean} [addTimestamp=true] Include a timestamp to payload
-     * @param {Boolean} [throwOnError=false] Throw if fallback errors
+     *
+     * You can use `forceCacheMiss` to always execute the `fallback`
+     * function thus bypassing the cache altogether.
+     *
+     * @param {String} key raw key
+     * @param {Function} fallback Called on cache miss
+     * @param {Object} options
+     * @param {Int} [options.ttl=defaultTTL] TTL for this key
+     * @param {Boolean} [options.serialize=true] Retrieve content as JSON
+     * @param {Boolean} [options.addTimestamp=true] Include a timestamp to payload
+     * @param {Boolean} [options.throwOnError=false] Throw if fallback errors
+     * @param {Boolean} [options.forceCacheMiss=false] Throw if fallback errors
+     * @param {Function} [options.forceCacheMiss] Called with current key and options
      * @returns {Promise}
      */
-    async tryGet(key, fallback, ttl = this.defaultTtl, serialize = true, addTimestamp = true, throwOnError = false) {
+    async tryGet(key, fallback, options = {}) {
+        options = extend({ ttl: this.defaultTTL }, this.tryGetOptions, options);
 
         key = this.hashKey(key);
 
-        this.logger.info('try to fetch key "%s" from cache...', key);
+        this.logger.info('try to fetch key "%s"...', key);
 
-        let value = await this.get(key, false, serialize);
+        let value;
+
+        if (this.shouldQueryCache(key, options)) {
+            this.logger.info('fetching key "%s" from cache...', key);
+            value = await this.get(key, false, options.serialize);
+        }
 
         if (value) {
             this.logger.info('value was cached, return');
@@ -77,20 +89,23 @@ class CacheClient extends EventEmitter {
         }
 
         try {
+            this.logger.info('calling fallback for key "%s"...', key);
+
             value = await fallback();
+
             /**
              * We want to mark when we last accessed
              * the real value
              */
-            this.makeTimestamp(value, addTimestamp);
+            this.makeTimestamp(value, options.addTimestamp);
 
-            await this.set(key, value, ttl);
+            await this.set(key, value, options.ttl);
         } catch (error) {
             value = { $error: error };
             this.logger.error('Error in cache try');
             this.logger.error(error.message);
             this.handleError(error, 'cache try error');
-            if (throwOnError) throw error;
+            if (options.throwOnError) throw error;
         }
 
         return value;
@@ -98,7 +113,7 @@ class CacheClient extends EventEmitter {
 
     /**
      * Retrieve key from store.
-     * 
+     *
      * @param {String} key cache key
      * @param {Any} def Any value
      * @param {Boolean} [deserialize=true] Return value as JSON
@@ -119,7 +134,7 @@ class CacheClient extends EventEmitter {
      * @param {Int} ttl Time to live for this key
      * @returns {Promise}
      */
-    set(key, value, ttl = this.defaultTtl) {
+    set(key, value, ttl = this.defaultTTL) {
         key = this.hashKey(key);
         if (typeof value !== 'string') value = this.serialize(value);
         return this.client.set(key, value, this.timeUnit, ttl);
@@ -137,8 +152,8 @@ class CacheClient extends EventEmitter {
 
     /**
      * Format key.
-     * @param {String} key raw value to hash 
-     * @param {Object} key raw value to hash 
+     * @param {String} key raw value to hash
+     * @param {Object} key raw value to hash
      * @returns {String} Formatted key
      */
     hashKey(key) {
@@ -152,6 +167,19 @@ class CacheClient extends EventEmitter {
     isHashKey(key) {
         if (typeof key !== 'string') key = this.serialize(key);
         return !!this.cacheKeyMatcher.exec(key);
+    }
+
+    shouldQueryCache(key, options) {
+        if (typeof options.forceCacheMiss === 'function') {
+            return options.forceCacheMiss(key, options);
+        }
+
+        /**
+         * If we set `forceCacheMiss` to true
+         * then we should skip cache and fallback
+         * to our source function.
+         */
+        return options.forceCacheMiss !== true;
     }
 
     get timeUnit() {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -15,7 +15,7 @@ module.exports = {
     hashKeys: true,
     cacheKeyPrefix: 'cache:',
     tryGetOptions: {
-        serialize: true,
+        deserialize: true,
         addTimestamp: true,
         throwOnError: false,
         forceCacheMiss: false,

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -7,13 +7,19 @@ const createClient = require('./createClient');
 module.exports = {
     autoinitialize: true,
     logger: extend.shim(console),
-    defaultTtl: (1 * 24 * 60 * 60 * 1000),
+    defaultTTL: (1 * 24 * 60 * 60 * 1000),
     lastError: null,
     ttlInSeconds: false,
     errors: [],
     createClient,
     hashKeys: true,
     cacheKeyPrefix: 'cache:',
+    tryGetOptions: {
+        serialize: true,
+        addTimestamp: true,
+        throwOnError: false,
+        forceCacheMiss: false,
+    },
     /**
      * Matches the string `cache:` followed
      * by an md5 hash.


### PR DESCRIPTION
We want to be able to conditionally skip cache hits / force cache miss so that we can bypass the cache and force a lookup.
In order to do that we refactored the signature of `tryGet` to accept an options object and introduce the `forceCacheMiss` option. If set to `true` it will force a cache miss. If is a function it will be called with key and options: `forceCacheMiss(key, options)`.

Add `purgeKeys` function which accepts a string pattern to match keys and all matching keys will be deleted.
