### PR TITLE
Handle timeouts

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -37,7 +37,10 @@ class CacheClient extends EventEmitter {
          */
         if (config.clientConnectionTimeout) {
             connectionId = setTimeout(_ => {
-                throw new CacheClientError(message, code);
+                this.logger.warn('Client connection time out.');
+                this.logger.warn('If your service needs TLS ensure your config is ok');
+                this.logger.warn('client option tls=%s', this.clientOptions.tls);
+                throw new CacheClientError('Client connection time out', code);
             }, config.clientConnectionTimeout);
         }
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,8 +1,9 @@
 'use strict';
-
+const promiseTimeout = require('p-timeout');
 const crypto = require('crypto');
 const extend = require('gextend');
 const EventEmitter = require('events');
+const { CacheClientError } = require('./errors');
 
 const defaults = require('./defaults');
 
@@ -25,6 +26,21 @@ class CacheClient extends EventEmitter {
             this.client = this.createClient(this.clientOptions);
         }
 
+        let connectionId;
+
+        /**
+         * TODO: This will most likely generate
+         * an uncaught error since is an async
+         * error from the constructor. For now
+         * it is ok since we want to throw if
+         * the redis connection is not ok.
+         */
+        if (config.clientConnectionTimeout) {
+            connectionId = setTimeout(_ => {
+                throw new CacheClientError(message, code);
+            }, config.clientConnectionTimeout);
+        }
+
         this.client.on('error', error => {
             this.handleError(error, 'Redis client error');
             this.emit('error', error);
@@ -37,6 +53,7 @@ class CacheClient extends EventEmitter {
 
         this.client.on('ready', event => {
             this.logger.info('redis ready event...');
+            clearTimeout(connectionId);
             this.emit('ready', event);
         });
 
@@ -62,6 +79,7 @@ class CacheClient extends EventEmitter {
      * @param {Function} fallback Called on cache miss
      * @param {Object} options
      * @param {Int} [options.ttl=defaultTTL] TTL for this key
+     * @param {Int} options.timeout Timeout in milliseconds for fallback function
      * @param {Boolean} [options.deserialize=true] Retrieve content as JSON
      * @param {Boolean} [options.addTimestamp=true] Include a timestamp to payload
      * @param {Boolean} [options.throwOnError=false] Throw if fallback errors
@@ -89,7 +107,15 @@ class CacheClient extends EventEmitter {
         try {
             this.logger.info('cache miss "%s"', key);
 
-            value = await fallback();
+            /**
+             * If we pass a timeout then listen for
+             * timeout errors.
+             */
+            if (options.timeout) {
+                value = await promiseTimeout(fallback(), options.timeout, new CacheClientError('Fallback function timeout', 408));
+            } else {
+                value = await fallback();
+            }
 
             /**
              * We want to mark when we last accessed
@@ -103,7 +129,12 @@ class CacheClient extends EventEmitter {
             this.logger.error('Error in cache try');
             this.logger.error(error.message);
             this.handleError(error, 'cache try error');
-            if (options.throwOnError) throw error;
+
+            /**
+             * If we had a timeout error then throw
+             */
+            if (error.code === 408) throw error;
+            else if (options.throwOnError) throw error;
         }
 
         return value;

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,7 +3,7 @@
 const extend = require('gextend');
 
 const createClient = require('./createClient');
-const _2_minutes = 2 * 60 * 1000;
+const _5_seconds = 5 * 1000;
 const _24_hours = (1 * 24 * 60 * 60 * 1000);
 
 module.exports = {
@@ -18,7 +18,7 @@ module.exports = {
      * Use TTL as seconds?
      */
     ttlInSeconds: false,
-    clientConnectionTimeout: _2_minutes,
+    clientConnectionTimeout: _5_seconds,
     lastError: null,
     errors: [],
     createClient,

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,13 +3,23 @@
 const extend = require('gextend');
 
 const createClient = require('./createClient');
+const _2_minutes = 2 * 60 * 1000;
+const _24_hours = (1 * 24 * 60 * 60 * 1000);
 
 module.exports = {
     autoinitialize: true,
     logger: extend.shim(console),
-    defaultTTL: (1 * 24 * 60 * 60 * 1000),
-    lastError: null,
+    /**
+     * TTL value for expire
+     * keys in milliseconds by default.
+     */
+    defaultTTL: _24_hours,
+    /**
+     * Use TTL as seconds?
+     */
     ttlInSeconds: false,
+    clientConnectionTimeout: _2_minutes,
+    lastError: null,
     errors: [],
     createClient,
     hashKeys: true,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,10 @@
+class CacheClientError extends Error {
+    constructor(message, code) {
+        super(message);
+        this.code = code;
+    }
+}
+
+module.exports = {
+    CacheClientError
+};

--- a/lib/init.js
+++ b/lib/init.js
@@ -16,7 +16,7 @@ module.exports = function(context, config) {
             const cache = new CacheClient(config);
 
             /**
-             * Expose a function to retrieve 
+             * Expose a function to retrieve
              * the redis client so that others can
              * use it
              */

--- a/package.json
+++ b/package.json
@@ -23,17 +23,18 @@
   "homepage": "https://github.com/goliatone/core.io-cache-redis#readme",
   "devDependencies": {
     "bogota": "^2.0.4",
-    "ioredis-mock": "^5.2.0",
-    "nyc": "^10.3.2",
-    "proxyquire": "^1.7.11",
-    "sinon": "^7.3.2",
+    "ioredis-mock": "^7.1.0",
+    "nyc": "^15.1.0",
+    "proxyquire": "^2.1.3",
+    "sinon": "^13.0.1",
     "tap-spec": "^5.0.0",
-    "tape": "^4.11.0",
+    "tape": "^5.5.2",
     "tape-catch": "^1.0.6",
     "watch": "^1.0.2"
   },
   "dependencies": {
     "gextend": "*",
-    "ioredis": "^4.19.4"
+    "ioredis": "^4.28.5",
+    "p-timeout": "^4.1.0"
   }
 }


### PR DESCRIPTION
This closes #1 by throwing an error if we don't connect to the redis server in a given amount of time.
Specify timeout setting the `clientConnectionTimeout` option.

You can also pass a timeout to the `tryGet` function, if present the `fallback` function will timeout after `timeout` and throw an error.