### PR TITLE
[FEAT] Add url option to createClient

### DIFF
--- a/lib/createClient.js
+++ b/lib/createClient.js
@@ -5,25 +5,32 @@ const extend = require('gextend');
 const defaults = {
     redisFactory(url) {
         const Redis = require('ioredis');
-
         return new Redis(url);
     }
 };
 
-function createClient(options = {}) {
-    options = extend({}, defaults, options);
+/**
+ * Create a new redis client.
+ *
+ * @param {Object} config Configuration options
+ * @returns
+ */
+function createClient(config = {}) {
+    config = extend({}, defaults, config);
 
-    const host = options.host;
-    const port = options.port;
-    const password = options.password;
+    if (config.url) return config.redisFactory(config.url);
 
-    const protocol = options.tls ? 'rediss' : 'redis';
+    const host = config.host;
+    const port = config.port;
+    const password = config.password;
+
+    const protocol = config.tls ? 'rediss' : 'redis';
 
     const queryString = password ? `?password=${encodeURIComponent(password)}` : '';
 
     const url = `${protocol}://${host}:${port}/${queryString}`;
 
-    return options.redisFactory(url);
+    return config.redisFactory(url);
 }
 
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Redis cache module",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/bogota",
-    "dtest": "watch ./node_modules/.bin/bogota tests/",
-    "cover": "./node_modules/.bin/nyc npm test"
+    "test": "tape ./tests/**.js | tap-spec",
+    "dtest": "watch 'npm test' ./tests",
+    "cover": "nyc npm test"
   },
   "repository": {
     "type": "git",
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/goliatone/core.io-cache-redis#readme",
   "devDependencies": {
-    "bogota": "^2.0.4",
     "ioredis-mock": "^7.1.0",
     "nyc": "^15.1.0",
     "proxyquire": "^2.1.3",


### PR DESCRIPTION
This PR closes #8 by adding a url option to `createClient`.
It also fixes the package.json `scripts` for tests.