### PR TITLE
[FIX]] Update `makeTimestamp` to do proper guard

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -51,9 +51,11 @@ module.exports = {
         return JSON.parse(value);
     },
     makeTimestamp(value, addTimestamp) {
-        if (typeof value === 'object' && addTimestamp) {
-            if (!value.hasOwnProperty('cachedOn')) value.cachedOn = Date.now();
-            else value._cachedOn = Date.now();
-        }
+        if (typeof value !== 'object' || !addTimestamp) return value;
+
+        if (value.hasOwnProperty('cachedOn')) value.cachedOn = Date.now();
+        else value._cachedOn = Date.now();
+
+        return value;
     }
 };


### PR DESCRIPTION
This PR closes #7 by refactoring the default `makeTimestamp` implementation.