### PR TITLE
Update tests and handle clear UUID keys

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,5 +1,4 @@
 'use strict';
-const promiseTimeout = require('p-timeout');
 const extend = require('gextend');
 const EventEmitter = require('events');
 const { CacheClientError } = require('./errors');
@@ -116,7 +115,7 @@ class CacheClient extends EventEmitter {
              * timeout errors.
              */
             if (options.timeout) {
-                value = await promiseTimeout(
+                value = await this.promiseTimeout(
                     fallback(rawKey),
                     options.timeout,
                     new CacheClientError('Fallback function timeout', 408)

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,6 +1,5 @@
 'use strict';
 const promiseTimeout = require('p-timeout');
-const crypto = require('crypto');
 const extend = require('gextend');
 const EventEmitter = require('events');
 const { CacheClientError } = require('./errors');
@@ -79,7 +78,7 @@ class CacheClient extends EventEmitter {
      * function thus bypassing the cache altogether.
      *
      * @param {String} key raw key
-     * @param {Function} fallback Called on cache miss
+     * @param {(key:string)} fallback Called on cache miss
      * @param {Object} options
      * @param {Int} [options.ttl=defaultTTL] TTL for this key
      * @param {Int} options.timeout Timeout in milliseconds for fallback function
@@ -93,7 +92,9 @@ class CacheClient extends EventEmitter {
     async tryGet(key, fallback, options = {}) {
         options = extend({ ttl: this.defaultTTL }, this.tryGetOptions, options);
 
-        key = this.hashKey(key);
+        let rawKey = key;
+
+        key = this.hashKey(rawKey);
 
         let value;
 
@@ -115,9 +116,13 @@ class CacheClient extends EventEmitter {
              * timeout errors.
              */
             if (options.timeout) {
-                value = await promiseTimeout(fallback(), options.timeout, new CacheClientError('Fallback function timeout', 408));
+                value = await promiseTimeout(
+                    fallback(rawKey),
+                    options.timeout,
+                    new CacheClientError('Fallback function timeout', 408)
+                );
             } else {
-                value = await fallback();
+                value = await fallback(rawKey);
             }
 
             /**
@@ -154,9 +159,12 @@ class CacheClient extends EventEmitter {
     async get(key, def, deserialize = true) {
         key = this.hashKey(key);
         let value = await this.client.get(key);
-        if (value && !deserialize) return value;
-        if (value && deserialize) return this.deserialize(value);
-        return def;
+
+        if (!value) return def;
+
+        if (deserialize) return this.deserialize(value);
+
+        return value;
     }
 
     /**
@@ -205,7 +213,7 @@ class CacheClient extends EventEmitter {
         if (typeof key !== 'string') key = this.keySerializer(key);
         if (this.isHashKey(key)) return key;
 
-        let hash = crypto.createHash('md5').update(key).digest('hex');
+        let hash = this.keyHashFunction(key);
 
         if (this.hasUUIDFormat(key) && this.hashUUIDs === false) {
             hash = key;

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -202,14 +202,20 @@ class CacheClient extends EventEmitter {
      */
     hashKey(key) {
         if (this.hashKeys === false) return key;
-        if (typeof key !== 'string') key = this.serialize(key);
+        if (typeof key !== 'string') key = this.keySerializer(key);
         if (this.isHashKey(key)) return key;
+
         let hash = crypto.createHash('md5').update(key).digest('hex');
+
+        if (this.hasUUIDFormat(key) && this.hashUUIDs === false) {
+            hash = key;
+        }
+
         return `${this.cacheKeyPrefix}${hash}`;
     }
 
     isHashKey(key) {
-        if (typeof key !== 'string') key = this.serialize(key);
+        if (typeof key !== 'string') key = this.keySerializer(key);
         return !!this.cacheKeyMatcher.exec(key);
     }
 
@@ -300,5 +306,7 @@ class CacheClient extends EventEmitter {
 }
 
 CacheClient.defaults = defaults;
+
+CacheClient.UUID_CACHE_MATCHER = /^cache:?(.*:)[-a-z0-9]{36}$/i;
 
 module.exports = CacheClient;

--- a/lib/createClient.js
+++ b/lib/createClient.js
@@ -2,11 +2,21 @@
 
 const extend = require('gextend');
 
-const defaults = {
-    redisFactory(url) {
-        const Redis = require('ioredis');
-        return new Redis(url);
-    }
+const defaults = (o = {}) => {
+
+    const env = o.env || process.env;
+
+    return {
+        url: env.REDIS_URL,
+        port: env.REDIS_PORT || 6379,
+        host: env.REDIS_HOST || 'localhost',
+        password: env.REDIS_PASSWORD,
+        tls: env.REDIS_TLS || false,
+        redisFactory(url) {
+            const Redis = require('ioredis');
+            return new Redis(url);
+        }
+    };
 };
 
 /**
@@ -16,7 +26,7 @@ const defaults = {
  * @returns
  */
 function createClient(config = {}) {
-    config = extend({}, defaults, config);
+    config = extend({}, defaults(config.env), config);
 
     if (config.url) return config.redisFactory(config.url);
 
@@ -28,7 +38,7 @@ function createClient(config = {}) {
 
     const queryString = password ? `?password=${encodeURIComponent(password)}` : '';
 
-    const url = `${protocol}://${host}:${port}/${queryString}`;
+    const url = `${protocol}://${host}:${port}` + queryString;
 
     return config.redisFactory(url);
 }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -38,11 +38,24 @@ module.exports = {
      * by an md5 hash.
      */
     cacheKeyMatcher: /^cache:[a-z0-9]{32}$/i,
+    /**
+     * Should we hash raw keys
+     * that have a UUID format?
+     */
+    hashUUIDs: true,
     clientOptions: {
         port: 6379,
         host: 'localhost',
         tls: false,
         showFriendlyErrorStack: true
+    },
+    /**
+     * Stringify raw key objects.
+     * @param {Object} obj Raw key
+     * @returns {string} Serialized key
+     */
+    keySerializer(obj) {
+        return this.serialize(obj);
     },
     serialize(obj) {
         return JSON.stringify(obj);
@@ -57,5 +70,20 @@ module.exports = {
         else value._cachedOn = Date.now();
 
         return value;
+    },
+    /**
+     * If `strict` is true then we use a
+     * regular expression for compatible with
+     * the RFC4122.
+     *
+     * @param {String} str
+     * @param {Boolean} [strict=false]
+     * @returns {Boolean}
+     */
+    hasUUIDFormat(str = '', strict = false) {
+        if (strict) {
+            return !!str.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+        }
+        return !!str.match(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/i);
     }
 };

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,6 +1,7 @@
 /*jshint esversion:6, node:true*/
 'use strict';
 const extend = require('gextend');
+const crypto = require('crypto');
 
 const createClient = require('./createClient');
 const _5_seconds = 5 * 1000;
@@ -56,6 +57,9 @@ module.exports = {
      */
     keySerializer(obj) {
         return this.serialize(obj);
+    },
+    keyHashFunction(key) {
+        return crypto.createHash('md5').update(key).digest('hex');
     },
     serialize(obj) {
         return JSON.stringify(obj);

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -2,6 +2,7 @@
 'use strict';
 const extend = require('gextend');
 const crypto = require('crypto');
+const _promiseTimeout = require('p-timeout');
 
 const createClient = require('./createClient');
 const _5_seconds = 5 * 1000;
@@ -44,12 +45,26 @@ module.exports = {
      * that have a UUID format?
      */
     hashUUIDs: true,
+
+    /**
+     * Default redis client options.
+     * These will be passed to the `createClient`
+     * function.
+     */
     clientOptions: {
         port: 6379,
         host: 'localhost',
         tls: false,
         showFriendlyErrorStack: true
     },
+
+    /**
+     * Promise with a timeout implementation.
+     */
+    promiseTimeout(fallback, timeout, error) {
+        return _promiseTimeout(fallback, timeout, error);
+    },
+
     /**
      * Stringify raw key objects.
      * @param {Object} obj Raw key

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/goliatone/core.io-cache-redis#readme",
   "devDependencies": {
     "ioredis-mock": "^7.1.0",
+    "noop-console": "^0.9.0",
     "nyc": "^15.1.0",
     "proxyquire": "^2.1.3",
     "sinon": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tape ./tests/**.js | tap-spec",
-    "dtest": "watch 'npm test' .",
+    "dtest": "watch 'npm test' . --ignoreDotFiles",
     "cover": "nyc npm test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tape ./tests/**.js | tap-spec",
-    "dtest": "watch 'npm test' ./tests",
+    "dtest": "watch 'npm test' .",
     "cover": "nyc npm test"
   },
   "repository": {

--- a/tests/cache_test.js
+++ b/tests/cache_test.js
@@ -6,7 +6,7 @@ const CacheClient = require('..').CacheClient;
 const fixtures = {};
 
 
-test('CacheClient: isHashKey should identify valid cache keys', t => {
+test('CacheClient: isHashKey should identify valid cache keys using default pattern', t => {
 
     let client = new CacheClient({
         createClient: function() {
@@ -39,7 +39,90 @@ test('CacheClient: isHashKey should identify valid cache keys', t => {
     }];
 
     keys.forEach(fixture => {
-        t.equals(client.isHashKey(fixture.key), fixture.expected);
+        const result = client.isHashKey(fixture.key);
+        t.equals(result, fixture.expected, `is "${fixture.key}" a hash hey? ${result}`);
+    });
+
+    t.end();
+});
+
+
+test('CacheClient: isHashKey should identify valid cache keys using custom pattern', t => {
+
+    let client = new CacheClient({
+        cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        createClient: function() {
+            const Redis = require('ioredis-mock');
+            return new Redis();
+        }
+    });
+
+    let keys = [{
+        key: 'adfadfa',
+        expected: false,
+    }, {
+        key: '0c19caba-aad2-4e64-b644-a2a546528912',
+        expected: false
+    }, {
+        key: 'cache:0c19caba-aad2-4e64-b644-a2a546528912',
+        expected: true
+    }, {
+        key: 'cache:cfe599a8705981bc9d8cf136591',
+        expected: false
+    }, {
+        key: 'cache:cfe599a8705981bc9d8cf136591e66bf',
+        expected: false
+    }, {
+        key: 'cache:4998c5a8-461f-44f7-9c2d-bb5ce3bbff91',
+        expected: true
+    }, {
+        key: 'cache:425b01ac-4c45-49ef-b3a0-3fcf64a4d116',
+        expected: true
+    }, {
+        key: 'cache:user:425b01ac-4c45-49ef-b3a0-3fcf64a4d116',
+        expected: true
+    }, {
+        key: 'cache:user:profile:425b01ac-4c45-49ef-b3a0-3fcf64a4d116',
+        expected: true
+    }];
+
+    keys.forEach(fixture => {
+        const result = client.isHashKey(fixture.key);
+        t.equals(result, fixture.expected, `is "${fixture.key}" a hash hey? ${result}`);
+    });
+
+    t.end();
+});
+
+
+test('CacheClient: hashKey should not hash UUIDs', t => {
+
+    let client = new CacheClient({
+        hashUUIDs: false,
+        cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        createClient: function() {
+            const Redis = require('ioredis-mock');
+            return new Redis();
+        }
+    });
+
+    let keys = [{
+        key: 'adfadfa',
+        expected: 'cache:9c9003d48dc9a1ee2bd97749db6c7cc7',
+    }, {
+        key: '0c19caba-aad2-4e64-b644-a2a546528912',
+        expected: 'cache:0c19caba-aad2-4e64-b644-a2a546528912'
+    }, {
+        key: 'cache:0c19caba-aad2-4e64-b644-a2a546528912',
+        expected: 'cache:0c19caba-aad2-4e64-b644-a2a546528912'
+    }, {
+        key: 'sample-raw-key',
+        expected: 'cache:69d9380fbea522ce22fa5bc88be74a8a'
+    }];
+
+    keys.forEach(fixture => {
+        const result = client.hashKey(fixture.key);
+        t.equals(result, fixture.expected, `"${fixture.key}" = "${result}"`);
     });
 
     t.end();

--- a/tests/cache_test.js
+++ b/tests/cache_test.js
@@ -2,22 +2,24 @@
 const test = require('tape');
 const sinon = require('sinon');
 const CacheClient = require('..').CacheClient;
+const noopConsole = require('noop-console');
 
 const fixtures = {};
 
-test('CacheClient: tryGet should use fallback when key not in cache', async t => {
+test('CacheClient: "tryGet" should use fallback when key not in cache', async t => {
     const fallback = _ => expected
     const expected = { user: 1, name: 'pepe' };
-    const key = '13136b36-bbcf-4127-bb03-28038065e9ba';
+    const key = '70d6e4c7-4da7-4bc9-9ecd-53e0c06a22ef';
 
-    const client = new CacheClient({
+    const cache = new CacheClient({
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis();
         }
     });
 
-    const result = await client.tryGet(key, fallback, {
+    const result = await cache.tryGet(key, fallback, {
         addTimestamp: false
     });
 
@@ -25,41 +27,15 @@ test('CacheClient: tryGet should use fallback when key not in cache', async t =>
     t.end();
 });
 
-test('CacheClient: tryGet should use cache when key is found', async t => {
+test('CacheClient: "tryGet" should use cache when key is found', async t => {
     const fallback = sinon.spy();
     const expected = { user: 1, name: 'pepe' };
-    const key = '13136b36-bbcf-4127-bb03-28038065e9ba';
+    const key = '54b798c8-2107-4641-817d-9a5212632c37';
 
-    const client = new CacheClient({
+    const cache = new CacheClient({
         hashUUIDs: false,
         cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
-        createClient: function() {
-            const Redis = require('ioredis-mock');
-            return new Redis({
-                data: {
-                    [`cache:${key}`]: expected
-                }
-            });
-        }
-    });
-
-    const result = await client.tryGet(key, fallback, {
-        addTimestamp: false
-    });
-
-    t.equals(result, expected, `result is expected object`);
-    t.ok(fallback.notCalled, 'fallback should not be called');
-
-    t.end();
-});
-
-test('CacheClient: get should return value', async t => {
-    const expected = { user: 1, name: 'pepe' };
-    const key = '13136b36-bbcf-4127-bb03-28038065e9ba';
-
-    const client = new CacheClient({
-        hashUUIDs: false,
-        cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis({
@@ -70,20 +46,49 @@ test('CacheClient: get should return value', async t => {
         }
     });
 
-    const result = await client.get(key);
+    const result = await cache.tryGet(key, fallback, {
+        addTimestamp: false
+    });
+
+    t.deepEquals(result, expected, `result is expected value`);
+    t.ok(fallback.notCalled, 'fallback should not be called');
+
+    t.end();
+});
+
+test('CacheClient: "get" should return value', async t => {
+    const expected = { user: 1, name: 'pepe' };
+    const key = '90dc29f8-027b-4fec-a011-ab07af159f5b';
+
+    const cache = new CacheClient({
+        hashUUIDs: false,
+        cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        logger: noopConsole(),
+        createClient: function() {
+            const Redis = require('ioredis-mock');
+            return new Redis({
+                data: {
+                    [`cache:${key}`]: JSON.stringify(expected)
+                }
+            });
+        }
+    });
+
+    const result = await cache.get(key);
 
     t.deepEquals(result, expected, `result is expected object`);
 
     t.end();
 });
 
-test('CacheClient: get should return value if we use full key', async t => {
+test('CacheClient: "get" should return value if we use full key', async t => {
     const expected = { user: 1, name: 'pepe' };
-    const key = 'cache:13136b36-bbcf-4127-bb03-28038065e9ba';
+    const key = 'cache:4b4509b7-9844-48a8-9906-16f9189fc547';
 
-    const client = new CacheClient({
+    const cache = new CacheClient({
         hashUUIDs: false,
         cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis({
@@ -94,7 +99,7 @@ test('CacheClient: get should return value if we use full key', async t => {
         }
     });
 
-    const result = await client.get(key);
+    const result = await cache.get(key);
 
     t.deepEquals(result, expected, `result is expected cached value`);
 
@@ -103,11 +108,12 @@ test('CacheClient: get should return value if we use full key', async t => {
 
 test('CacheClient: "get" should return string if "deserialize" is `false`', async t => {
     const expected = `{ user: 1, name: 'pepe' }`;
-    const key = '13136b36-bbcf-4127-bb03-28038065e9ba';
+    const key = '0dffa433-5b80-4ef4-ba73-085e22a0f030';
 
-    const client = new CacheClient({
+    const cache = new CacheClient({
         hashUUIDs: false,
         cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis({
@@ -118,7 +124,7 @@ test('CacheClient: "get" should return string if "deserialize" is `false`', asyn
         }
     });
 
-    const result = await client.get(key, undefined, false);
+    const result = await cache.get(key, undefined, false);
 
     t.deepEquals(result, expected, `result is expected string`);
 
@@ -127,53 +133,109 @@ test('CacheClient: "get" should return string if "deserialize" is `false`', asyn
 
 test('CacheClient: "get" should return default value if key not found', async t => {
     const expected = { user: 1, name: 'pepe' };
-    const key = '13136b36-bbcf-4127-bb03-28038065e9ba';
+    const key = '872e3fc6-a9b3-4412-a25f-0750bf14ab10';
 
-    const client = new CacheClient({
+    const cache = new CacheClient({
         hashUUIDs: false,
         cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis({ data: {} });
         }
     });
 
-    const result = await client.get(key, expected);
-
+    const result = await cache.get(key, expected);
+    console.log('======= result', result);
     t.deepEquals(result, expected, `result is expected object`);
 
     t.end();
 });
 
-test('CacheClient: "set" should set a value we can retrieve with "get"', async t => {
+test.only('CacheClient: "set" should set a value we can retrieve with "get"', async t => {
     const expected = { user: 1, name: 'pepe' };
-    const key = 'cache:13136b36-bbcf-4127-bb03-28038065e9ba';
+    const key = 'cache:6b0fc92e-409e-41d0-87c7-1c5bbcaea54b';
 
-    const client = new CacheClient({
+    const cache = new CacheClient({
         hashUUIDs: false,
         cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis();
         }
     });
 
-    await client.set(key, expected);
+    await cache.set(key, expected);
 
-    const result = await client.get(key);
+    const result = await cache.get(key);
 
     t.deepEquals(result, expected, `result is expected cached value`);
 
     t.end();
 });
 
+test('CacheClient: "set" should use a default TTL value', async t => {
+    const expected = { user: 1, name: 'pepe' };
+    const key = 'cache:7e2b336f-a2db-4249-a2ea-164acc3a8b56';
+    const defaultTTL = 100;
+
+    const cache = new CacheClient({
+        defaultTTL,
+        hashUUIDs: false,
+        cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        logger: noopConsole(),
+        createClient: function() {
+            const Redis = require('ioredis-mock');
+            return new Redis();
+        }
+    });
+
+    const set = sinon.stub(cache.client, 'set');
+
+    set.callsFake((key, value, unit, ttl) => {
+        t.equals(ttl, defaultTTL, 'should be called with default TTL');
+        t.end();
+        set.restore();
+    });
+
+    await cache.set(key, expected);
+});
+
+test('CacheClient: "set" should use given TTL argument', async t => {
+    const expected = { user: 1, name: 'pepe' };
+    const key = 'cache:7e2b336f-a2db-4249-a2ea-164acc3a8b56';
+    const argTTL = 100;
+
+    const cache = new CacheClient({
+        hashUUIDs: false,
+        cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        logger: noopConsole(),
+        createClient: function() {
+            const Redis = require('ioredis-mock');
+            return new Redis();
+        }
+    });
+
+    const set = sinon.stub(cache.client, 'set');
+
+    set.callsFake((key, value, unit, ttl) => {
+        t.equals(ttl, argTTL, 'should be called with TTL argument');
+        t.end();
+        set.restore();
+    });
+
+    await cache.set(key, expected, argTTL);
+});
+
 test('CacheClient: "del" should delete a value', async t => {
     const expected = { user: 1, name: 'pepe' };
     const key = 'cache:13136b36-bbcf-4127-bb03-28038065e9ba';
 
-    const client = new CacheClient({
+    const cache = new CacheClient({
         hashUUIDs: false,
         cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis({
@@ -184,13 +246,13 @@ test('CacheClient: "del" should delete a value', async t => {
         }
     });
 
-    let result = await client.get(key);
+    let result = await cache.get(key);
 
     t.deepEquals(result, expected, `result is expected cached value`);
 
-    await client.del(key);
+    await cache.del(key);
 
-    result = await client.get(key);
+    result = await cache.get(key);
 
     t.notOk(result, 'After delete we should not find key');
 
@@ -199,7 +261,8 @@ test('CacheClient: "del" should delete a value', async t => {
 
 test('CacheClient: isHashKey should identify valid cache keys using default pattern', t => {
 
-    const client = new CacheClient({
+    const cache = new CacheClient({
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis();
@@ -230,7 +293,7 @@ test('CacheClient: isHashKey should identify valid cache keys using default patt
     }];
 
     keys.forEach(fixture => {
-        const result = client.isHashKey(fixture.key);
+        const result = cache.isHashKey(fixture.key);
         t.equals(result, fixture.expected, `is "${fixture.key}" a hash hey? ${result}`);
     });
 
@@ -239,8 +302,9 @@ test('CacheClient: isHashKey should identify valid cache keys using default patt
 
 test('CacheClient: isHashKey should identify valid cache keys using custom pattern', t => {
 
-    const client = new CacheClient({
+    const cache = new CacheClient({
         cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis();
@@ -277,7 +341,7 @@ test('CacheClient: isHashKey should identify valid cache keys using custom patte
     }];
 
     keys.forEach(fixture => {
-        const result = client.isHashKey(fixture.key);
+        const result = cache.isHashKey(fixture.key);
         t.equals(result, fixture.expected, `is "${fixture.key}" a hash hey? ${result}`);
     });
 
@@ -286,9 +350,10 @@ test('CacheClient: isHashKey should identify valid cache keys using custom patte
 
 test('CacheClient: hashKey should not hash UUIDs', t => {
 
-    const client = new CacheClient({
+    const cache = new CacheClient({
         hashUUIDs: false,
         cacheKeyMatcher: CacheClient.UUID_CACHE_MATCHER,
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis();
@@ -310,7 +375,7 @@ test('CacheClient: hashKey should not hash UUIDs', t => {
     }];
 
     keys.forEach(fixture => {
-        const result = client.hashKey(fixture.key);
+        const result = cache.hashKey(fixture.key);
         t.equals(result, fixture.expected, `"${fixture.key}" = "${result}"`);
     });
 
@@ -318,29 +383,31 @@ test('CacheClient: hashKey should not hash UUIDs', t => {
 });
 
 test('CacheClient: ttl in seconds use EX', t => {
-    const client = new CacheClient({
+    const cache = new CacheClient({
         ttlInSeconds: true,
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis();
         }
     });
 
-    const result = client.timeUnit;
+    const result = cache.timeUnit;
     t.equals(result, 'EX', `"EX" = "${result}"`);
     t.end();
 });
 
 test('CacheClient: ttl in milliseconds use PX', t => {
-    const client = new CacheClient({
+    const cache = new CacheClient({
         ttlInSeconds: false,
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis();
         }
     });
 
-    const result = client.timeUnit;
+    const result = cache.timeUnit;
     t.equals(result, 'PX', `"PX" = "${result}"`);
     t.end();
 });

--- a/tests/createClient_test.js
+++ b/tests/createClient_test.js
@@ -112,8 +112,6 @@ function setEnv(options = defaultOptions) {
     if (options.host) process.env.REDIS_HOST = options.host;
     if (options.password) process.env.REDIS_PASSWORD = options.password;
     if (options.tls) process.env.REDIS_TLS = options.tls;
-    console.log('setEnv url', options.url);
-    console.log('setEnv REDIS_URL', process.env.REDIS_URL);
 }
 
 function delEnv() {

--- a/tests/createClient_test.js
+++ b/tests/createClient_test.js
@@ -1,0 +1,125 @@
+'use strict';
+const test = require('tape');
+
+const createClient = require('..').createClient;
+
+const fixtures = {};
+
+test('createClient: should use config.url', t => {
+    const defaultURL = 'redis://localhost:6379';
+
+    const result = createClient(merge({
+        url: defaultURL,
+        redisFactory: url => url
+    }));
+
+    t.deepEquals(result, defaultURL, `should match ${result} = ${defaultURL}`);
+
+    t.end();
+});
+
+test('createClient: should use process.env.REDIS_URL', t => {
+    const defaultURL = 'rediss://localhost:3333';
+
+    setEnv(merge({ url: defaultURL }));
+
+    const result = createClient({
+        redisFactory: url => url
+    });
+
+    t.deepEquals(result, defaultURL, `should match ${result} = ${defaultURL}`);
+
+    delEnv();
+
+    t.end();
+});
+
+
+test('createClient: should use process.env options', t => {
+    const defaultURL = 'rediss://127.0.0.0:3333';
+
+    setEnv(merge({
+        port: 3333,
+        host: '127.0.0.0',
+        tls: true
+    }));
+
+    const result = createClient({
+        redisFactory: url => url
+    });
+
+    t.deepEquals(result, defaultURL, `should match ${result} = ${defaultURL}`);
+
+    delEnv();
+
+    t.end();
+});
+
+test('createClient: should use config default options to build url', t => {
+    const defaultURL = 'redis://localhost:6379';
+
+    const result = createClient(merge({
+        redisFactory: url => url
+    }));
+
+    t.deepEquals(result, defaultURL, `should match ${result} = ${defaultURL}`);
+
+    t.end();
+});
+
+test('createClient: should use password to build url', t => {
+    const password = 'pwd';
+    const defaultURL = `redis://localhost:6379?password=${password}`;
+
+    const result = createClient(merge({
+        password,
+        redisFactory: url => url
+    }));
+
+    t.deepEquals(result, defaultURL, `should match ${result} = ${defaultURL}`);
+
+    t.end();
+});
+
+test('createClient: should use tls', t => {
+    const defaultURL = `rediss://localhost:6379`;
+
+    const result = createClient(merge({
+        tls: true,
+        redisFactory: url => url
+    }));
+
+    t.deepEquals(result, defaultURL, `should match ${result} = ${defaultURL}`);
+
+    t.end();
+});
+
+const defaultOptions = {
+    url: undefined,
+    port: 6379,
+    host: 'localhost',
+    password: undefined,
+    tls: false,
+};
+
+function merge(options = {}) {
+    return Object.assign({}, defaultOptions, options);
+}
+
+function setEnv(options = defaultOptions) {
+    if (options.url) process.env.REDIS_URL = options.url;
+    if (options.port) process.env.REDIS_PORT = options.port;
+    if (options.host) process.env.REDIS_HOST = options.host;
+    if (options.password) process.env.REDIS_PASSWORD = options.password;
+    if (options.tls) process.env.REDIS_TLS = options.tls;
+    console.log('setEnv url', options.url);
+    console.log('setEnv REDIS_URL', process.env.REDIS_URL);
+}
+
+function delEnv() {
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_PORT;
+    delete process.env.REDIS_HOST;
+    delete process.env.REDIS_PASSWORD;
+    delete process.env.REDIS_TLS;
+}

--- a/tests/serialization_test.js
+++ b/tests/serialization_test.js
@@ -2,6 +2,7 @@
 const test = require('tape');
 
 const CacheClient = require('..').CacheClient;
+const noopConsole = require('noop-console');
 
 const fixtures = {};
 
@@ -9,6 +10,7 @@ const fixtures = {};
 test('CacheClient: should handle custom serialization', t => {
 
     let client = new CacheClient({
+        logger: noopConsole(),
         createClient: function() {
             const Redis = require('ioredis-mock');
             return new Redis();


### PR DESCRIPTION
This PR closes #12 so we now accept raw keys formatted as UUIDs and are not going to be hashed.

Small refactoring of defaults configuration object:
	* move `promiseTimeout` to defaults
	* add `keySerializer`
	* add `keyHashFunction`
	* add `hasUUIDFormat`