### PR TITLE
[FIX] Add try catch to `get`

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -98,8 +98,17 @@ class CacheClient extends EventEmitter {
         let value;
 
         if (this.shouldQueryCache(key, options)) {
-            this.logger.info('fetching "%s"', key);
-            value = await this.get(key, false, options.deserialize);
+            try {
+                this.logger.info('fetching "%s"', key);
+                value = await this.get(key, false, options.deserialize);
+            } catch (error) {
+                value = { $error: error };
+                this.logger.error('Cache error while fetching key');
+                this.logger.error(error.message);
+                this.handleError(error, 'cache get error');
+
+                if (options.throwOnError) throw error;
+            }
         }
 
         if (value) {
@@ -133,9 +142,9 @@ class CacheClient extends EventEmitter {
             await this.set(key, value, options.ttl);
         } catch (error) {
             value = { $error: error };
-            this.logger.error('Error in cache try');
+            this.logger.error('Cache error while calling fallback function');
             this.logger.error(error.message);
-            this.handleError(error, 'cache try error');
+            this.handleError(error, 'cache fallback error');
 
             /**
              * If we had a timeout error then throw


### PR DESCRIPTION
This PR closes #13 by handling `this.get` errors inside `tryGet`