### PR TITLE
[FEAT] Refactor get/set to take options

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -79,9 +79,10 @@ class CacheClient extends EventEmitter {
      * @param {String} key raw key
      * @param {(key:string)} fallback Called on cache miss
      * @param {Object} options
-     * @param {Int} [options.ttl=defaultTTL] TTL for this key
+     * @param {Int} [options.ttl=this.defaultTTL] TTL for this key
      * @param {Int} options.timeout Timeout in milliseconds for fallback function
-     * @param {Boolean} [options.deserialize=true] Retrieve content as JSON
+     * @param {Function | Boolean} [options.deserialize=true] Save content e.g. as JSON
+     * @param {Function} [options.serialize=this.serialize] Retrieve content as e.g. JSON
      * @param {Boolean} [options.addTimestamp=true] Include a timestamp to payload
      * @param {Boolean} [options.throwOnError=false] Throw if fallback errors
      * @param {Boolean} [options.forceCacheMiss=false] Throw if fallback errors
@@ -100,11 +101,9 @@ class CacheClient extends EventEmitter {
         if (this.shouldQueryCache(key, options)) {
             try {
                 this.logger.info('fetching "%s"', key);
-                value = await this.get(key, false, options.deserialize);
+                value = await this.get(key, false, options);
             } catch (error) {
                 value = { $error: error };
-                this.logger.error('Cache error while fetching key');
-                this.logger.error(error.message);
                 this.handleError(error, 'cache get error');
 
                 if (options.throwOnError) throw error;
@@ -132,18 +131,8 @@ class CacheClient extends EventEmitter {
             } else {
                 value = await fallback(rawKey);
             }
-
-            /**
-             * We want to mark when we last accessed
-             * the real value
-             */
-            this.makeTimestamp(value, options.addTimestamp);
-
-            await this.set(key, value, options.ttl);
         } catch (error) {
             value = { $error: error };
-            this.logger.error('Cache error while calling fallback function');
-            this.logger.error(error.message);
             this.handleError(error, 'cache fallback error');
 
             /**
@@ -151,6 +140,21 @@ class CacheClient extends EventEmitter {
              */
             if (error.code === 408) throw error;
             else if (options.throwOnError) throw error;
+        }
+
+        try {
+            /**
+             * We want to mark when we last accessed
+             * the real value
+             */
+            this.makeTimestamp(value, options.addTimestamp);
+
+            await this.set(key, value, options);
+        } catch (error) {
+            value = { $error: error };
+            this.handleError(error, 'cache set error');
+
+            if (options.throwOnError) throw error;
         }
 
         return value;
@@ -161,16 +165,36 @@ class CacheClient extends EventEmitter {
      *
      * @param {String} key cache key
      * @param {Any} def Any value
-     * @param {Boolean} [deserialize=true] Return value as JSON
+     * @param {Object} options
+     * @param {Boolean} [options.deserialize=true] Return value as JSON
+     * @param {Boolean} [options.buffer=false] Get key as binary data
      * @returns {Promise}
      */
-    async get(key, def, deserialize = true) {
+    async get(key, def, options = {}) {
         key = this.hashKey(key);
-        let value = await this.client.get(key);
+
+        if (typeof options === 'boolean') {
+            options = { deserialize: options };
+        }
+
+        let { deserialize, buffer } = extend({
+            buffer: false,
+            deserialize: true,
+        }, options);
+
+        let value = buffer ?
+            this.client.getBuffer(key) :
+            this.client.get(key);
+
+        value = await value;
 
         if (!value) return def;
 
-        if (deserialize) return this.deserialize(value);
+        if (deserialize === true) {
+            return this.deserialize(value);
+        }
+
+        if (typeof deserialize === 'function') return deserialize(value);
 
         return value;
     }
@@ -179,12 +203,26 @@ class CacheClient extends EventEmitter {
      * Set a key in cache
      * @param {String} key cache key
      * @param {Object|String} value Value to cache
-     * @param {Int} ttl Time to live for this key
+     * @param {Object} options
+     * @param {Int} [options.ttl=this.defaultTTL] Time to live for this key
      * @returns {Promise}
      */
-    set(key, value, ttl = this.defaultTTL) {
+    set(key, value, options = {}) {
         key = this.hashKey(key);
-        if (typeof value !== 'string') value = this.serialize(value);
+
+        let defaultTTL = this.defaultTTL;
+        if (typeof options === 'number') {
+            defaultTTL = options;
+            options = {};
+        }
+
+        let { ttl, serialize } = extend({
+            ttl: defaultTTL,
+            serialize: this.serialize
+        }, options);
+
+        if (typeof value !== 'string') value = serialize(value);
+
         return this.client.set(key, value, this.timeUnit, ttl);
     }
 
@@ -289,8 +327,7 @@ class CacheClient extends EventEmitter {
             });
 
             stream.on('error', error => {
-                this.logger.error('Error purging keys: %s', match);
-                this.logger.error(error);
+                this.handleError(error, `purge keys error: ${match}`);
                 reject(error);
             });
         });


### PR DESCRIPTION
This PR refactors `set` and `get` methods to take an options object so that we can pass in custom serialize and deserialize functions on a per cache object. 
It also adds support for storing raw buffers in redis by using `getBuffer`.