### PR TITLE
[fix] ensure we can match cached keys

### DIFF
--- a/lib/cacheBatch.js
+++ b/lib/cacheBatch.js
@@ -70,6 +70,14 @@ class BatchCacheClient extends CacheClient {
             cachedValues = await this.getBatch(getKeys, [], options);
         }
 
+        /**
+         * If all keys were found in
+         * the cache. Return values...
+         */
+        if (notEmpty(cachedValues) === rawKeys.length) {
+            return cachedValues;
+        }
+
         let values = [],
             batchKeys = [],
             batchValues = [],
@@ -99,14 +107,6 @@ class BatchCacheClient extends CacheClient {
             }
         }
 
-        /**
-         * Great! All keys were found in
-         * the cache. Return values...
-         */
-        if (values.length === rawKeys.length) {
-            return values;
-        }
-
         try {
             /**
              * If we pass a timeout then listen for
@@ -133,6 +133,7 @@ class BatchCacheClient extends CacheClient {
             else return values;
         }
 
+        const setValues = [];
         for (const i in batchValues) {
             let value = batchValues[i];
             /**
@@ -153,11 +154,14 @@ class BatchCacheClient extends CacheClient {
              * given index in the return
              * object.
              */
-            values[index] = value;
+            if (index) {
+                values[index] = value;
+                setValues.push(value);
+            }
         }
 
         try {
-            await this.setBatch(batchKeys, values, options);
+            await this.setBatch(batchKeys, setValues, options);
         } catch (error) {
             values = { $error: error };
             this.handleError(error, 'cache setBatch error');
@@ -267,4 +271,9 @@ function notValidArguments(keys, values) {
     if (keys.length === 0 || values.length === 0) return true;
     if (keys.length !== values.length) return true;
     return false;
+}
+
+
+function notEmpty(a = []) {
+    return a.filter(a => a != null).length;
 }

--- a/tests/batch_test.js
+++ b/tests/batch_test.js
@@ -83,6 +83,54 @@ test('CacheClientBatch: "tryGetBatch" should "setBatch" for keys not in cache', 
     t.end();
 });
 
+
+test('CacheClientBatch: "tryGetBatch" should "setBatch" for some keys not in cache', async t => {
+    const user1 = { user: 1, name: 'user1' };
+    const key1 = '70d6e4c7-4da7-4bc9-9ecd-53e0c06a22ef';
+
+    const user2 = { user: 2, name: 'user2' };
+    const key2 = 'b6fdfba9-d8f9-40a2-a2a7-51fc34dddffc';
+
+    const user3 = { user: 3, name: 'user3' };
+    const key3 = '877fc553-0c31-49f0-b5b9-7beda30017d8';
+
+    const cache = new CacheClientBatch({
+        hashUUIDs: false,
+        logger: noopConsole(),
+        cacheKeyMatcher: UUID_CACHE_MATCHER,
+        createClient: () => new Redis({
+            data: {
+                [`cache:${key1}`]: JSON.stringify(user1)
+            }
+        })
+    });
+
+    const keys = [key1, key2, key3];
+    const expected = [user1, user2, user3];
+
+    const setKeys = [key2, key3];
+    const setValues = [user2, user3];
+
+    const fallback = sinon.stub();
+    fallback.returns(setValues);
+
+    const setBatch = sinon.spy(cache, 'setBatch');
+
+    const result = await cache.tryGetBatch(keys, fallback, {
+        addTimestamp: false
+    });
+
+    t.deepEquals(result, expected, `result is expected object`);
+    t.ok(fallback.calledOnce, 'fallback should have been called once');
+    t.ok(fallback.calledWith(setKeys), 'fallback should have been with raw key');
+    t.ok(setBatch.calledWith(setKeys, setValues), 'setBatch should have been called');
+
+    setBatch.restore();
+    await cache.client.flushall();
+
+    t.end();
+});
+
 test('CacheClientBatch: "tryGetBatch" should use "promiseTimeout" if timeout is set', async t => {
     const user1 = { user: 1, name: 'user1' };
     const key1 = '70d6e4c7-4da7-4bc9-9ecd-53e0c06a22ef';


### PR DESCRIPTION
This PR fixes issues with `tryGetBatch` that would not properly handle the case in which one or more of the requested keys were already in the cache.
Also updates tests to capture that scenario. 