### PR TITLE
Add support for asynchronous 

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -69,13 +69,13 @@ class CacheClient extends EventEmitter {
 
         let rawKey = key;
 
-        key = this.hashKey(rawKey);
+        key = this.hashKey(rawKey, options);
 
         let value;
 
         if (this.shouldQueryCache(key, options)) {
             try {
-                this.logger.info('fetching "%s"', key);
+                this.logger.info('fetch "%s"', key);
                 value = await this.get(key, false, options);
             } catch (error) {
                 value = { $error: error };
@@ -85,7 +85,7 @@ class CacheClient extends EventEmitter {
         }
 
         if (value) {
-            this.logger.info('returning cached value!');
+            this.logger.info('cache OK "%s"', key);
             return value;
         }
 
@@ -166,10 +166,10 @@ class CacheClient extends EventEmitter {
         if (!value) return def;
 
         if (deserialize === true) {
-            return this.deserialize(value);
+            return await this.deserialize(value);
         }
 
-        if (typeof deserialize === 'function') return deserialize(value);
+        if (typeof deserialize === 'function') return await deserialize(value);
 
         return value;
     }
@@ -182,8 +182,8 @@ class CacheClient extends EventEmitter {
      * @param {Int} [options.ttl=this.defaultTTL] Time to live for this key
      * @returns {Promise}
      */
-    set(key, value, options = {}) {
-        key = this.hashKey(key);
+    async set(key, value, options = {}) {
+        key = this.hashKey(key, options);
 
         let defaultTTL = this.defaultTTL;
         if (typeof options === 'number') {
@@ -196,7 +196,7 @@ class CacheClient extends EventEmitter {
             serialize: this.serialize
         }, options);
 
-        if (typeof value !== 'string') value = serialize(value);
+        if (typeof value !== 'string') value = await serialize(value);
 
         return this.client.set(key, value, this.timeUnit, ttl);
     }
@@ -208,7 +208,7 @@ class CacheClient extends EventEmitter {
      * @returns {Promise}
      */
     del(key) {
-        key = this.hashKey(key);
+        key = this.hashKey(key, options);
         return this.client.del(key);
     }
 
@@ -229,12 +229,12 @@ class CacheClient extends EventEmitter {
      * @param {Object} key raw value to hash
      * @returns {String} Formatted key
      */
-    hashKey(key) {
+    hashKey(key, options = {}) {
         if (this.hashKeys === false) return key;
-        if (typeof key !== 'string') key = this.keySerializer(key);
-        if (this.isHashKey(key)) return key;
+        if (typeof key !== 'string') key = this.keySerializer(key, options);
+        if (this.isHashKey(key, options)) return key;
 
-        let hash = this.keyHashFunction(key);
+        let hash = this.keyHashFunction(key, options);
 
         if (this.hasUUIDFormat(key) && this.hashUUIDs === false) {
             hash = key;
@@ -243,7 +243,7 @@ class CacheClient extends EventEmitter {
         return `${this.cacheKeyPrefix}${hash}`;
     }
 
-    isHashKey(key) {
+    isHashKey(key, options = {}) {
         if (typeof key !== 'string') key = this.keySerializer(key);
         return !!this.cacheKeyMatcher.exec(key);
     }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -166,10 +166,10 @@ class CacheClient extends EventEmitter {
         if (!value) return def;
 
         if (deserialize === true) {
-            return await this.deserialize(value);
+            return await this.deserialize(value, options);
         }
 
-        if (typeof deserialize === 'function') return await deserialize(value);
+        if (typeof deserialize === 'function') return await deserialize(value, options);
 
         return value;
     }
@@ -196,7 +196,7 @@ class CacheClient extends EventEmitter {
             serialize: this.serialize
         }, options);
 
-        if (typeof value !== 'string') value = await serialize(value);
+        if (typeof value !== 'string') value = await serialize(value, options);
 
         return this.client.set(key, value, this.timeUnit, ttl);
     }
@@ -244,7 +244,7 @@ class CacheClient extends EventEmitter {
     }
 
     isHashKey(key, options = {}) {
-        if (typeof key !== 'string') key = this.keySerializer(key);
+        if (typeof key !== 'string') key = this.keySerializer(key, options);
         return !!this.cacheKeyMatcher.exec(key);
     }
 

--- a/lib/cacheBatch.js
+++ b/lib/cacheBatch.js
@@ -45,7 +45,7 @@ class BatchCacheClient extends CacheClient {
          * Ensure we get all rightly
          * formatted keys.
          */
-        keys = this.hashKeyBatch(keys);
+        keys = this.hashKeyBatch(keys, options);
 
 
         let getKeys = [],
@@ -184,7 +184,7 @@ class BatchCacheClient extends CacheClient {
             deserialize: this.deserialize,
         }, o);
 
-        keys = this.hashKeyBatch(keys);
+        keys = this.hashKeyBatch(keys, o);
 
         /**
          * mget always returns an array.
@@ -198,15 +198,15 @@ class BatchCacheClient extends CacheClient {
 
         values = await values;
 
-        const _deserializer = val => {
+        const _deserializer = (val, o) => {
             if (!deserialize || val == null) return val;
             return typeof deserialize === 'function' ?
-                deserialize(val) :
-                this.deserialize(val);
+                deserialize(val, o) :
+                this.deserialize(val, o);
         };
 
         for (const index in values) {
-            let value = _deserializer(values[index]);
+            let value = await _deserializer(values[index], o);
             if (value === null && (index in defs)) {
                 value = defs[index];
             }
@@ -216,8 +216,7 @@ class BatchCacheClient extends CacheClient {
         return values;
     }
 
-    setBatch(keys, values, o = {}) {
-
+    async setBatch(keys, values, o = {}) {
         if (notValidArguments(keys, values)) {
             throw new CacheClientError(
                 getMessage(keys, values, 'Argument error'),
@@ -237,7 +236,7 @@ class BatchCacheClient extends CacheClient {
         for (const index in keys) {
             let key = keys[index];
             let value = values[index];
-            if (typeof value !== 'string') value = serialize(value);
+            if (typeof value !== 'string') value = await serialize(value, o);
             if (value) tx.set(key, value, this.timeUnit, ttl);
         }
 
@@ -249,9 +248,9 @@ class BatchCacheClient extends CacheClient {
      * @param {Array} keys cache key
      * @returns {Promise}
      */
-    delBatch(keys) {
+    delBatch(keys, options = {}) {
         if (!Array.isArray(keys)) keys = [keys];
-        keys = this.hashKeyBatch(keys);
+        keys = this.hashKeyBatch(keys, options);
         return this.client.del(keys);
     }
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -67,10 +67,10 @@ module.exports = {
      * @param {Object} obj Raw key
      * @returns {string} Serialized key
      */
-    keySerializer(obj) {
+    keySerializer(obj, options = {}) {
         return this.serialize(obj);
     },
-    keyHashFunction(key) {
+    keyHashFunction(key, options = {}) {
         return crypto.createHash('md5').update(key).digest('hex');
     },
     serialize(obj) {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -36,7 +36,7 @@ module.exports = {
      * Matches the string `cache:` followed
      * by an md5 hash.
      */
-    cacheKeyMatcher: /^cache:[a-z0-9]{32}$/i,
+    cacheKeyMatcher: /^cache:(.*)$/i,
     /**
      * Should we hash raw keys
      * that have a UUID format?

--- a/tests/batch_test.js
+++ b/tests/batch_test.js
@@ -380,7 +380,6 @@ test('CacheClientBatch: "tryGetBatch" should "setBatch" for some keys not in cac
 
     const fallback = sinon.stub();
     fallback.callsFake(keys => {
-        console.log('keys', keys);
         return users.filter(item => keys.includes(item.id))
     });
 

--- a/tests/batch_test.js
+++ b/tests/batch_test.js
@@ -1103,26 +1103,26 @@ test('CacheClientBatch: "setBatch" should throw if invalid arguments', async t =
     });
 
     try {
-        cache.setBatch();
+        await cache.setBatch();
     } catch (error) {
         t.ok(error, 'should throw with invalid arguments');
     }
 
     try {
-        cache.setBatch('key');
+        await cache.setBatch('key');
     } catch (error) {
         t.ok(error, 'should throw with invalid arguments');
     }
 
     try {
-        cache.setBatch(['key'], 'value');
+        await cache.setBatch(['key'], 'value');
     } catch (error) {
         t.ok(error, 'should throw with invalid arguments');
     }
 
     let expectedError;
     try {
-        cache.setBatch(['key'], ['value']);
+        await cache.setBatch(['key'], ['value']);
     } catch (error) {
         expectedError = error;
     }
@@ -1212,27 +1212,28 @@ test('CacheClient: hashKeyBatch should not hash UUIDs', t => {
 
     const cache = new CacheClientBatch({
         hashUUIDs: false,
-        cacheKeyMatcher: UUID_CACHE_MATCHER,
         logger: noopConsole(),
         createClient: () => new Redis()
     });
 
     let keys = [
-        'adfadfa',
+        'getAllRecords:[0-100]',
         '0c19caba-aad2-4e64-b644-a2a546528912',
         'cache:0c19caba-aad2-4e64-b644-a2a546528912',
-        'sample-raw-key',
+        'cache:user:688e9ef9-6592-4543-bbe3-f66d2716aca0:profile'
     ];
 
     let expected = [
-        'cache:9c9003d48dc9a1ee2bd97749db6c7cc7',
+        'cache:5f53a329ca71b0a130e07b96b15ca8af',
         'cache:0c19caba-aad2-4e64-b644-a2a546528912',
         'cache:0c19caba-aad2-4e64-b644-a2a546528912',
-        'cache:69d9380fbea522ce22fa5bc88be74a8a'
+        'cache:user:688e9ef9-6592-4543-bbe3-f66d2716aca0:profile'
     ];
 
     const result = cache.hashKeyBatch(keys);
-    t.deepEquals(result, expected, `batch keys`);
+    for (const i in result) {
+        t.deepEquals(result[i], expected[i], `${result[i]} = ${expected[i]}`);
+    }
 
     t.end();
 });

--- a/tests/cache_test.js
+++ b/tests/cache_test.js
@@ -925,17 +925,17 @@ test('CacheClient: isHashKey should identify valid cache keys using default patt
     });
 
     let keys = [{
-        key: 'adfadfa',
+        key: 'getAllRecords:[0-100]',
         expected: false,
     }, {
         key: '0c19caba-aad2-4e64-b644-a2a546528912',
         expected: false
     }, {
         key: 'cache:0c19caba-aad2-4e64-b644-a2a546528912',
-        expected: false
+        expected: true
     }, {
         key: 'cache:cfe599a8705981bc9d8cf136591',
-        expected: false
+        expected: true
     }, {
         key: 'cache:cfe599a8705981bc9d8cf136591e66bf',
         expected: true
@@ -966,17 +966,17 @@ test('CacheClient: isHashKey should use keySerializer for non string keys', t =>
     });
 
     let keys = [{
-        keyObject: { id: 'adfadfa' },
+        keyObject: { id: 'MWMxNTNlNzMzMzNmOGM0YWMwNDg3NGM1NjQ0MzEzNjQ=' },
         expected: false,
     }, {
         keyObject: { id: '0c19caba-aad2-4e64-b644-a2a546528912' },
         expected: false
     }, {
         keyObject: { id: 'cache:0c19caba-aad2-4e64-b644-a2a546528912' },
-        expected: false
+        expected: true
     }, {
         keyObject: { id: 'cache:cfe599a8705981bc9d8cf136591' },
-        expected: false
+        expected: true
     }, {
         keyObject: { id: 'cache:cfe599a8705981bc9d8cf136591e66bf' },
         expected: true

--- a/tests/serialization_test.js
+++ b/tests/serialization_test.js
@@ -1,20 +1,54 @@
 'use strict';
 const test = require('tape');
-
+const Redis = require('ioredis-mock');
 const CacheClient = require('..').CacheClient;
 const noopConsole = require('noop-console');
 
-const fixtures = {};
+test('CacheClient: should hash keys', t => {
+
+    let client = new CacheClient({
+        logger: noopConsole(),
+        hashUUIDs: false,
+        createClient: () => new Redis()
+    });
+
+    let keys = [{
+        key: 'getAllRecords:[0-100]',
+        expected: 'cache:5f53a329ca71b0a130e07b96b15ca8af',
+    }, {
+        key: '5f53a329ca71b0a130e07b96b15ca8af',
+        expected: 'cache:1c153e73333f8c4ac04874c564431364'
+    }, {
+        key: '0c19caba-aad2-4e64-b644-a2a546528912',
+        expected: 'cache:0c19caba-aad2-4e64-b644-a2a546528912'
+    }, {
+        key: 'cache:cfe599a8705981bc9d8cf136591',
+        expected: 'cache:cfe599a8705981bc9d8cf136591'
+    }, {
+        key: 'cache:4F56EDCB1558D4DF2F77295F86059006',
+        expected: 'cache:4F56EDCB1558D4DF2F77295F86059006'
+    }, {
+        key: 'cache:user:688e9ef9-6592-4543-bbe3-f66d2716aca0:profile',
+        expected: 'cache:user:688e9ef9-6592-4543-bbe3-f66d2716aca0:profile'
+    }];
+
+    keys.forEach(fixture => {
+        t.equals(
+            client.hashKey(fixture.key),
+            fixture.expected,
+            `${fixture.key} = ${fixture.expected}`,
+        );
+    });
+
+    t.end();
+});
 
 
 test('CacheClient: should handle custom serialization', t => {
 
     let client = new CacheClient({
         logger: noopConsole(),
-        createClient: function() {
-            const Redis = require('ioredis-mock');
-            return new Redis();
-        },
+        createClient: () => new Redis(),
         serialize(obj) {
             return JSON.stringify(obj);
         },
@@ -24,17 +58,17 @@ test('CacheClient: should handle custom serialization', t => {
     });
 
     let keys = [{
-        key: 'adfadfa',
+        key: 'getAllRecords:[0-100]',
         expected: false,
     }, {
         key: '0c19caba-aad2-4e64-b644-a2a546528912',
         expected: false
     }, {
         key: 'cache:0c19caba-aad2-4e64-b644-a2a546528912',
-        expected: false
+        expected: true
     }, {
         key: 'cache:cfe599a8705981bc9d8cf136591',
-        expected: false
+        expected: true
     }, {
         key: 'cache:cfe599a8705981bc9d8cf136591e66bf',
         expected: true


### PR DESCRIPTION
This PR closes #31 by adding support for async ser/de.

* Add support for asynchronous ser/de operations. 
* Fix how we propagate options to all key functions.


**NOTE**
By default, `keySerializer` is mapped to be the same as `serialize` HOWEVER at the moment `hashKey` is not asynchronous. 