### PR TITLE
[FIX] Handle empty values in `tryGetBatch` and `tryGet`

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -95,6 +95,10 @@ class CacheClient extends EventEmitter {
             /**
              * If we pass a timeout then listen for
              * timeout errors.
+             * It is to the developer's discretion
+             * how to handle 404s.
+             * They could potentially throw an error
+             * or just return null/undefined.
              */
             if (options.timeout) {
                 value = await this.promiseTimeout(
@@ -116,6 +120,12 @@ class CacheClient extends EventEmitter {
             else if (options.throwOnError) throw error;
             else return value;
         }
+
+        /**
+         * If value is either null or undefined
+         * we return value but do not cache it.
+         */
+        if (value == null) return value;
 
         try {
             /**
@@ -197,7 +207,6 @@ class CacheClient extends EventEmitter {
         }, options);
 
         if (typeof value !== 'string') value = await serialize(value, options);
-
         return this.client.set(key, value, this.timeUnit, ttl);
     }
 

--- a/lib/cacheBatch.js
+++ b/lib/cacheBatch.js
@@ -126,6 +126,11 @@ class BatchCacheClient extends CacheClient {
             else return values;
         }
 
+        /**
+         * Our fallback function returned no values
+         */
+        if (batchValues.length === 0) return [];
+
         for (const value of batchValues) {
             /**
              * We want to mark when we last accessed

--- a/tests/batch_test.js
+++ b/tests/batch_test.js
@@ -969,6 +969,50 @@ test('CacheClientBatch: "tryGetBatch" should return empty values array', async t
     t.end();
 });
 
+
+test('CacheClientBatch: "tryGetBatch" should return from cache and null fallback', async t => {
+    const key1 = '70d6e4c7-4da7-4bc9-9ecd-53e0c06a22ef';
+    const user1 = { user: key1, name: 'user1' };
+
+    const key2 = 'b6fdfba9-d8f9-40a2-a2a7-51fc34dddffc';
+
+    const key3 = '877fc553-0c31-49f0-b5b9-7beda30017d8';
+    const user3 = { user: key3, name: 'user3' };
+
+    const cache = new CacheClientBatch({
+        hashUUIDs: false,
+        logger: noopConsole(),
+        cacheKeyMatcher: UUID_CACHE_MATCHER,
+        createClient: () => new Redis({
+            data: {
+                [`cache:${key1}`]: JSON.stringify(user1),
+                [`cache:${key3}`]: JSON.stringify(user3),
+            }
+        })
+    });
+
+    const keys = [key1, key2, key3];
+    const expected = [user1, null, user3];
+
+    const fallback = sinon.stub();
+    fallback.returns([null]);
+
+    const getBatch = sinon.spy(cache, 'getBatch');
+
+    const result = await cache.tryGetBatch(keys, fallback, {
+        addTimestamp: false
+    });
+
+    t.deepEquals(result, expected, `result is expected object`);
+    t.ok(fallback.calledOnce, 'fallback should not have been called');
+    t.ok(getBatch.calledTwice, 'getBatch should have been called twice');
+
+    getBatch.restore();
+    await cache.client.flushall();
+
+    t.end();
+});
+
 test('CacheClientBatch: "getBatch" should return default values for things not in cache', async t => {
     const user1 = { user: 1, name: 'user1' };
     const key1 = '70d6e4c7-4da7-4bc9-9ecd-53e0c06a22ef';

--- a/tests/cache_test.js
+++ b/tests/cache_test.js
@@ -550,6 +550,37 @@ test('CacheClient: "tryGet" should call "promiseTimeout" if timeout is set', asy
     t.end();
 });
 
+test.only('CacheClient: "tryGet" should return empty values', async t => {
+    const expected = undefined;
+    const key = '62dd0765-ad4b-4c65-b7a1-6a82c07da45a';
+
+
+    const cache = new CacheClient({
+        hashUUIDs: false,
+        cacheKeyMatcher: UUID_CACHE_MATCHER,
+        logger: noopConsole(),
+        createClient: () => new Redis()
+    });
+
+    const fallback = sinon.stub();
+    fallback.returns(expected);
+
+    const set = sinon.spy(cache, 'set');
+
+    const result = await cache.tryGet(key, fallback, {
+        addTimestamp: false,
+    });
+
+    t.deepEquals(result, expected, `result is expected value`);
+    t.ok(fallback.calledOnce, 'fallback should have been called once');
+    t.ok(set.notCalled, 'set should have been called once');
+
+    set.restore();
+    await cache.client.flushall();
+
+    t.end();
+});
+
 test('CacheClient: "get" should return value', async t => {
     const expected = { user: 1, name: 'pepe' };
     const key = '90dc29f8-027b-4fec-a011-ab07af159f5b';

--- a/tests/cache_test.js
+++ b/tests/cache_test.js
@@ -550,7 +550,7 @@ test('CacheClient: "tryGet" should call "promiseTimeout" if timeout is set', asy
     t.end();
 });
 
-test.only('CacheClient: "tryGet" should return empty values', async t => {
+test('CacheClient: "tryGet" should return empty values', async t => {
     const expected = undefined;
     const key = '62dd0765-ad4b-4c65-b7a1-6a82c07da45a';
 


### PR DESCRIPTION
This addresses the case in which `fallback` returns an empty value or value set. Updated specs to test these cases. 